### PR TITLE
Windows batch encoded in UTF-8 (using chcp 65001)

### DIFF
--- a/extension/OOoLilyPond/LilyPond.xba
+++ b/extension/OOoLilyPond/LilyPond.xba
@@ -82,7 +82,7 @@ Function CallLilyPond() As Boolean
 
 	ElseIf sOSType = &quot;Windows&quot; Then
 
-		sCommand = &quot;cd /d &quot; &amp; Chr(34) &amp; ConvertFromURL(sTmpPath) &amp; Chr(34) &amp; Chr(10) _
+		sCommand = &quot;cd /d &quot; &amp; Chr(34) &amp; ConvertFromURL(sTmpPath) &amp; Chr(34) &amp; Chr(10) &amp; Chr(13) _
 		&amp; Chr(34) &amp; sLilyPondExecutable &amp; Chr(34) &amp; &quot; -dno-point-and-click&quot;
 		If Len(sIncludeStatement) &gt; 0 Then
 			sCommand = sCommand &amp; &quot; &quot; &amp; sIncludeStatement
@@ -91,21 +91,21 @@ Function CallLilyPond() As Boolean
 			If bTransparentBackground Then
 				sCommand = sCommand &amp; &quot; -dno-delete-intermediate-files -dpixmap-format=pngalpha --png &quot; &amp; sBackendOpt &amp; &quot; -dresolution=&quot; _
 				&amp; iGraphicDPI &amp; &quot; &quot;&amp; Chr(34) &amp; ConvertFromURL(sTmpPath) &amp; constOLyFileName &amp; &quot;.ly&quot; &amp; Chr (34) _
-				&amp; &quot; &gt;&quot; &amp; constOLyFileName &amp; &quot;.out 2&gt;&amp;1&quot; &amp;Chr(10)
+				&amp; &quot; &gt;&quot; &amp; constOLyFileName &amp; &quot;.out 2&gt;&amp;1&quot; &amp; Chr(10) &amp; Chr(13)
 			Else
 				sCommand = sCommand &amp; &quot; -dno-delete-intermediate-files --png &quot; &amp; sBackendOpt &amp; &quot; -dresolution=&quot; _
 				&amp; iGraphicDPI &amp; &quot; &quot; &amp; Chr(34) &amp; ConvertFromURL(sTmpPath) &amp; constOLyFileName &amp; &quot;.ly&quot; &amp; Chr (34) _
-			&amp; &quot; &gt;&quot; &amp; constOLyFileName &amp; &quot;.out 2&gt;&amp;1&quot; &amp;Chr(10)
+			&amp; &quot; &gt;&quot; &amp; constOLyFileName &amp; &quot;.out 2&gt;&amp;1&quot; &amp; Chr(10) &amp; Chr(13)
 			End If
 		ElseIf sFormat=&quot;eps&quot; Then
 			sCommand = sCommand &amp; &quot; &quot; &amp; sBackendOpt &amp; &quot; -f eps &quot; &amp; Chr(34) &amp; ConvertFromURL(sTmpPath) &amp; constOLyFileName &amp; &quot;.ly&quot; &amp; Chr (34) _
-			&amp; &quot; &gt;&quot; &amp; constOLyFileName &amp; &quot;.out 2&gt;&amp;1&quot; &amp; Chr(10)
+			&amp; &quot; &gt;&quot; &amp; constOLyFileName &amp; &quot;.out 2&gt;&amp;1&quot; &amp; Chr(10) &amp; Chr(13)
 		ElseIf sFormat=&quot;svg&quot; Then
 			sCommand = sCommand &amp; &quot; &quot; &amp; sBackendOpt &amp; &quot; &quot; &amp; Chr(34) &amp; ConvertFromURL(sTmpPath) &amp; constOLyFileName &amp; &quot;.ly&quot; &amp; Chr (34) _
-			&amp; &quot; &gt;&quot; &amp; constOLyFileName &amp; &quot;.out 2&gt;&amp;1&quot; &amp; Chr(10)
+			&amp; &quot; &gt;&quot; &amp; constOLyFileName &amp; &quot;.out 2&gt;&amp;1&quot; &amp; Chr(10) &amp; Chr(13)
 		End If
-		sCommand=sCommand &amp; &quot;if %ERRORLEVEL% equ 9009 echo cannot execute &gt;LilyPond-cannot_execute&quot; &amp; Chr(10) _
-		&amp; &quot;if %ERRORLEVEL% equ 3 echo cannot execute &gt;LilyPond-cannot_execute&quot; &amp; Chr(10)
+		sCommand=sCommand &amp; &quot;if %ERRORLEVEL% equ 9009 echo cannot execute &gt;LilyPond-cannot_execute&quot; &amp; Chr(10) &amp; Chr(13) _
+		&amp; &quot;if %ERRORLEVEL% equ 3 echo cannot execute &gt;LilyPond-cannot_execute&quot; &amp; Chr(10) &amp; Chr(13)
 		&apos;ToDo: 9009 and 3 OK? Other errors? Wrong Permissions?
 		WindowsCommand(sCommand)
 

--- a/extension/OOoLilyPond/Tools.xba
+++ b/extension/OOoLilyPond/Tools.xba
@@ -336,8 +336,6 @@ End Function
 
 Sub WindowsCommand(sCommand as String)
 	
-	BasicLibraries.loadLibrary(&quot;XrayTool&quot;)
-	
 	&apos; I did not achieve to run lilypond directly with the Shell command and the 
 	&apos; Output redirected to files.
 	&apos; I tried: Shell(&quot;cmd /c lilypond &gt;file1 2&gt;file2&quot;)

--- a/extension/OOoLilyPond/Tools.xba
+++ b/extension/OOoLilyPond/Tools.xba
@@ -352,14 +352,12 @@ Sub WindowsCommand(sCommand as String)
 	&apos; Open output stream
 	oTextStream  = createUnoService(&quot;com.sun.star.io.TextOutputStream&quot;)
 	If oFileAccess.exists( sBatFile ) Then oFileAccess.kill( sBatFile )
-    oTextStream.setOutputStream(oFileAccess.openFileWrite(sBatFile)) 
+	oTextStream.setOutputStream(oFileAccess.openFileWrite(sBatFile)) 
     
-    &apos;Set CodePage to 65001 - which is UTF-8 (Supports any except bidirectional and scripted languages)
-    oTextStream.setEncoding(&quot;utf-8&quot;)
-	&apos; On Windows/LibreOffice utf-8 files are saved starting with a 2-byte BOM.
-	&apos; Using a newline and carriage return to skip to the next line
-    oTextStream.writeString( Chr(10) &amp; Chr(13) )
-    oTextStream.writeString(&quot;chcp 65001&quot; &amp; Chr(10) &amp; Chr(13) &amp; sCommand)
+	&apos;Set CodePage to 65001 - which is UTF-8 (Supports any except bidirectional and scripted languages)
+	oTextStream.setEncoding(&quot;utf-8&quot;)
+	oTextStream.writeString( Chr(10) &amp; Chr(13) )
+	oTextStream.writeString(&quot;chcp 65001&quot; &amp; Chr(10) &amp; Chr(13) &amp; sCommand)
 	oTextStream.closeOutput()
 
 	Shell (sBatFile, 6, &quot;&quot;, True) &apos; Window-code 6 : only show symbol and leave focus on the current window

--- a/extension/OOoLilyPond/Tools.xba
+++ b/extension/OOoLilyPond/Tools.xba
@@ -335,6 +335,9 @@ End Function
 
 
 Sub WindowsCommand(sCommand as String)
+	
+	BasicLibraries.loadLibrary(&quot;XrayTool&quot;)
+	
 	&apos; I did not achieve to run lilypond directly with the Shell command and the 
 	&apos; Output redirected to files.
 	&apos; I tried: Shell(&quot;cmd /c lilypond &gt;file1 2&gt;file2&quot;)
@@ -344,15 +347,26 @@ Sub WindowsCommand(sCommand as String)
 
 	Dim sBatFile As String
 	Dim iNumber As Integer
+	Dim oTextStream As Object
 
 	sBatFile=TmpFileName(ConvertFromURL(sTmpPath) &amp; &quot;CommandCallFromOOo_&quot;,&quot;.bat&quot;)
+	
+	&apos; Open output stream
+	oTextStream  = createUnoService(&quot;com.sun.star.io.TextOutputStream&quot;)
+	If oFileAccess.exists( sBatFile ) Then oFileAccess.kill( sBatFile )
+    oTextStream.setOutputStream(oFileAccess.openFileWrite(sBatFile)) 
+    
+    &apos;Set CodePage to 65001 - which is UTF-8 (Supports any except bidirectional and scripted languages)
+    oTextStream.setEncoding(&quot;utf-8&quot;)
+	&apos; On Windows/LibreOffice utf-8 files are saved starting with a 2-byte BOM.
+	&apos; Using a newline and carriage return to skip to the next line
+    oTextStream.writeString( Chr(10) &amp; Chr(13) )
+    oTextStream.writeString(&quot;chcp 65001&quot; &amp; Chr(10) &amp; Chr(13) &amp; sCommand)
+	oTextStream.closeOutput()
 
-	iNumber = Freefile
-	Open sBatFile For Output As #iNumber
-	Print #iNumber, &quot;chcp 1252&quot; &amp; Chr (10) &amp; sCommand
-	Close #iNumber
-	Shell (sBatFile, 1, &quot;&quot;, True)
+	Shell (sBatFile, 6, &quot;&quot;, True) &apos; Window-code 6 : only show symbol and leave focus on the current window
 	Kill(sBatFile)
+	
 End Sub
 
 


### PR DESCRIPTION
Hello,

inspired by the workaround you found ( issue #27 ) this patch is using `TextOutputStream.setEncoding("utf-8")` and then codepage 65001 inside the batch file.
Hopefully this covers more languages (any except bidirectional and scripted).

Cheers,
Hannes E. Schäuble 