### PR TITLE
replace LFCR by CRLF in windows batch file

### DIFF
--- a/extension/OOoLilyPond/LilyPond.xba
+++ b/extension/OOoLilyPond/LilyPond.xba
@@ -82,7 +82,7 @@ Function CallLilyPond() As Boolean
 
 	ElseIf sOSType = &quot;Windows&quot; Then
 
-		sCommand = &quot;cd /d &quot; &amp; Chr(34) &amp; ConvertFromURL(sTmpPath) &amp; Chr(34) &amp; Chr(10) &amp; Chr(13) _
+		sCommand = &quot;cd /d &quot; &amp; Chr(34) &amp; ConvertFromURL(sTmpPath) &amp; Chr(34) &amp; Chr(13) &amp; Chr(10) _
 		&amp; Chr(34) &amp; sLilyPondExecutable &amp; Chr(34) &amp; &quot; -dno-point-and-click&quot;
 		If Len(sIncludeStatement) &gt; 0 Then
 			sCommand = sCommand &amp; &quot; &quot; &amp; sIncludeStatement
@@ -91,21 +91,21 @@ Function CallLilyPond() As Boolean
 			If bTransparentBackground Then
 				sCommand = sCommand &amp; &quot; -dno-delete-intermediate-files -dpixmap-format=pngalpha --png &quot; &amp; sBackendOpt &amp; &quot; -dresolution=&quot; _
 				&amp; iGraphicDPI &amp; &quot; &quot;&amp; Chr(34) &amp; ConvertFromURL(sTmpPath) &amp; constOLyFileName &amp; &quot;.ly&quot; &amp; Chr (34) _
-				&amp; &quot; &gt;&quot; &amp; constOLyFileName &amp; &quot;.out 2&gt;&amp;1&quot; &amp; Chr(10) &amp; Chr(13)
+				&amp; &quot; &gt;&quot; &amp; constOLyFileName &amp; &quot;.out 2&gt;&amp;1&quot; &amp; Chr(13) &amp; Chr(10)
 			Else
 				sCommand = sCommand &amp; &quot; -dno-delete-intermediate-files --png &quot; &amp; sBackendOpt &amp; &quot; -dresolution=&quot; _
 				&amp; iGraphicDPI &amp; &quot; &quot; &amp; Chr(34) &amp; ConvertFromURL(sTmpPath) &amp; constOLyFileName &amp; &quot;.ly&quot; &amp; Chr (34) _
-			&amp; &quot; &gt;&quot; &amp; constOLyFileName &amp; &quot;.out 2&gt;&amp;1&quot; &amp; Chr(10) &amp; Chr(13)
+			&amp; &quot; &gt;&quot; &amp; constOLyFileName &amp; &quot;.out 2&gt;&amp;1&quot; &amp; Chr(13) &amp; Chr(10)
 			End If
 		ElseIf sFormat=&quot;eps&quot; Then
 			sCommand = sCommand &amp; &quot; &quot; &amp; sBackendOpt &amp; &quot; -f eps &quot; &amp; Chr(34) &amp; ConvertFromURL(sTmpPath) &amp; constOLyFileName &amp; &quot;.ly&quot; &amp; Chr (34) _
-			&amp; &quot; &gt;&quot; &amp; constOLyFileName &amp; &quot;.out 2&gt;&amp;1&quot; &amp; Chr(10) &amp; Chr(13)
+			&amp; &quot; &gt;&quot; &amp; constOLyFileName &amp; &quot;.out 2&gt;&amp;1&quot; &amp; Chr(13) &amp; Chr(10)
 		ElseIf sFormat=&quot;svg&quot; Then
 			sCommand = sCommand &amp; &quot; &quot; &amp; sBackendOpt &amp; &quot; &quot; &amp; Chr(34) &amp; ConvertFromURL(sTmpPath) &amp; constOLyFileName &amp; &quot;.ly&quot; &amp; Chr (34) _
-			&amp; &quot; &gt;&quot; &amp; constOLyFileName &amp; &quot;.out 2&gt;&amp;1&quot; &amp; Chr(10) &amp; Chr(13)
+			&amp; &quot; &gt;&quot; &amp; constOLyFileName &amp; &quot;.out 2&gt;&amp;1&quot; &amp; Chr(13) &amp; Chr(10)
 		End If
-		sCommand=sCommand &amp; &quot;if %ERRORLEVEL% equ 9009 echo cannot execute &gt;LilyPond-cannot_execute&quot; &amp; Chr(10) &amp; Chr(13) _
-		&amp; &quot;if %ERRORLEVEL% equ 3 echo cannot execute &gt;LilyPond-cannot_execute&quot; &amp; Chr(10) &amp; Chr(13)
+		sCommand=sCommand &amp; &quot;if %ERRORLEVEL% equ 9009 echo cannot execute &gt;LilyPond-cannot_execute&quot; &amp; Chr(13) &amp; Chr(10) _
+		&amp; &quot;if %ERRORLEVEL% equ 3 echo cannot execute &gt;LilyPond-cannot_execute&quot; &amp; Chr(13) &amp; Chr(10)
 		&apos;ToDo: 9009 and 3 OK? Other errors? Wrong Permissions?
 		WindowsCommand(sCommand)
 

--- a/extension/OOoLilyPond/Tools.xba
+++ b/extension/OOoLilyPond/Tools.xba
@@ -356,8 +356,9 @@ Sub WindowsCommand(sCommand as String)
     
 	&apos;Set CodePage to 65001 - which is UTF-8 (Supports any except bidirectional and scripted languages)
 	oTextStream.setEncoding(&quot;utf-8&quot;)
-	oTextStream.writeString( Chr(10) &amp; Chr(13) )
-	oTextStream.writeString(&quot;chcp 65001&quot; &amp; Chr(10) &amp; Chr(13) &amp; sCommand)
+	&apos;Windows/LibreOffice writes a 2-byte BOM to mark an UTF-8 file: Skip to first statement with a new line
+	oTextStream.writeString( Chr(13) &amp; Chr(10) )
+	oTextStream.writeString(&quot;chcp 65001&quot; &amp; Chr(13) &amp; Chr(10) &amp; sCommand)
 	oTextStream.closeOutput()
 
 	Shell (sBatFile, 6, &quot;&quot;, True) &apos; Window-code 6 : only show symbol and leave focus on the current window


### PR DESCRIPTION
Hello,

I did a code review again and noticed that I confused the order of `Chr(10)` and `Chr(13)` in the `WindowsCommand` content. So I replaced LFCR by CRLF which is standard.

Cheers,
Hannes E. Schäuble